### PR TITLE
cleanup, add env vars to base images

### DIFF
--- a/devkita64/Dockerfile
+++ b/devkita64/Dockerfile
@@ -2,8 +2,7 @@ FROM devkitpro/toolchain-base
 
 MAINTAINER Dave Murphy <davem@devkitpro.org>
 
-ARG DEBIAN_FRONTEND=noninteractive
-
-RUN dkp-pacman -Syyu --noconfirm switch-dev
-
-RUN sudo dkp-pacman -S --needed --noconfirm `dkp-pacman -Slq dkp-libs | grep '^switch-'`
+RUN dkp-pacman -Syyu --noconfirm switch-dev && \
+    dkp-pacman -S --needed --noconfirm `dkp-pacman -Slq dkp-libs | grep '^switch-'` && \
+    dkp-pacman -Scc --noconfirm
+ENV DEVKITA64=${DEVKITPRO}/devkitA64

--- a/devkita64/Dockerfile
+++ b/devkita64/Dockerfile
@@ -5,4 +5,4 @@ MAINTAINER Dave Murphy <davem@devkitpro.org>
 RUN dkp-pacman -Syyu --noconfirm switch-dev && \
     dkp-pacman -S --needed --noconfirm `dkp-pacman -Slq dkp-libs | grep '^switch-'` && \
     dkp-pacman -Scc --noconfirm
-ENV DEVKITA64=${DEVKITPRO}/devkitA64
+

--- a/devkitarm/Dockerfile
+++ b/devkitarm/Dockerfile
@@ -2,8 +2,7 @@ FROM devkitpro/toolchain-base
 
 MAINTAINER Dave Murphy <davem@devkitpro.org>
 
-ARG DEBIAN_FRONTEND=noninteractive
-
-RUN  dkp-pacman -Syyu --noconfirm 3ds-dev nds-dev gp32-dev gba-dev
-
-RUN sudo dkp-pacman -S --needed --noconfirm `dkp-pacman -Slq dkp-libs | grep '^3ds-'`
+RUN dkp-pacman -Syyu --noconfirm 3ds-dev nds-dev gp32-dev gba-dev && \
+    dkp-pacman -S --needed --noconfirm `dkp-pacman -Slq dkp-libs | grep '^3ds-'` && \
+    dkp-pacman -Scc --noconfirm
+ENV DEVKITARM=${DEVKITPRO}/devkitARM

--- a/devkitppc/Dockerfile
+++ b/devkitppc/Dockerfile
@@ -2,8 +2,7 @@ FROM devkitpro/toolchain-base
 
 MAINTAINER Dave Murphy <davem@devkitpro.org>
 
-ARG DEBIAN_FRONTEND=noninteractive
-
-RUN  dkp-pacman -Syyu --noconfirm gamecube-dev wii-dev
-
-RUN sudo dkp-pacman -S --needed --noconfirm `dkp-pacman -Slq dkp-libs | grep '^ppc-'`
+RUN dkp-pacman -Syyu --noconfirm gamecube-dev wii-dev && \
+    dkp-pacman -S --needed --noconfirm `dkp-pacman -Slq dkp-libs | grep '^ppc-'` && \
+    dkp-pacman -Scc --noconfirm
+ENV DEVKITPPC=${DEVKITPRO}/devkitPPC

--- a/toolchain-base/Dockerfile
+++ b/toolchain-base/Dockerfile
@@ -2,12 +2,16 @@ FROM debian:stretch
 
 MAINTAINER Dave Murphy <davem@devkitpro.org>
 
-ARG DEBIAN_FRONTEND=noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
+RUN apt-get update && \
+    apt-get install -y apt-utils && \
+    apt-get install -y --no-install-recommends ca-certificates pkg-config curl wget bzip2 xz-utils make git bsdtar doxygen gnupg && \
+    apt-get clean
 
-RUN apt-get update && apt-get install -y apt-utils
-RUN apt-get install -y pkg-config curl wget bzip2 xz-utils make git bsdtar doxygen sudo gnupg
+RUN wget https://github.com/devkitPro/pacman/releases/download/devkitpro-pacman-1.0.1/devkitpro-pacman.deb && \
+    dpkg -i devkitpro-pacman.deb && \
+    rm devkitpro-pacman.deb
 
-RUN wget https://github.com/devkitPro/pacman/releases/download/devkitpro-pacman-1.0.1/devkitpro-pacman.deb
-
-RUN dpkg -i devkitpro-pacman.deb && rm devkitpro-pacman.deb
+ENV DEVKITPRO=/opt/devkitpro
+ENV PATH=${DEVKITPRO}/tools/bin:$PATH


### PR DESCRIPTION
Cleans up the Dockerfiles a bit:

- Batches RUN with rm/clean to remove extra files from within the same layer (saves space)
- Use ENV instead of ARG for DEBIAN_FRONTEND, which makes it only needed in the toolchain-base Dockerfile
- Adds ENV DEVKIT* variables as needed so you don't need to source profiles all the time