### PR TITLE
Add DEVKITARM environment variable

### DIFF
--- a/devkita64_devkitarm/Dockerfile
+++ b/devkita64_devkitarm/Dockerfile
@@ -4,4 +4,4 @@ MAINTAINER Dave Murphy <davem@devkitpro.org>
 
 RUN dkp-pacman -Sy --noconfirm devkitARM && \
     dkp-pacman -Scc --noconfirm
-
+ENV DEVKITARM=${DEVKITPRO}/devkitARM


### PR DESCRIPTION
This pull request adds the `DEVKITARM` environment variable to the `devkita64_devkitarm` image.

My reasons for adding this:
- consistency with the `devkitarm` image
- allows projects to use the `DEVKITARM` environment variable without further setup