### PR TITLE
Add cmake and corresponding toolchain files, add zip, fix $PATH for devkitA64 to work with cmake

### DIFF
--- a/devkita64/Dockerfile
+++ b/devkita64/Dockerfile
@@ -7,3 +7,4 @@ RUN dkp-pacman -Syyu --noconfirm switch-dev && \
     dkp-pacman -Scc --noconfirm && \
     dkp-pacman -S --needed --noconfirm devkitpro-pkgbuild-helpers
 
+ENV PATH=$DEVKITPRO/devkitA64/bin:$PATH

--- a/devkita64/Dockerfile
+++ b/devkita64/Dockerfile
@@ -4,5 +4,6 @@ MAINTAINER Dave Murphy <davem@devkitpro.org>
 
 RUN dkp-pacman -Syyu --noconfirm switch-dev && \
     dkp-pacman -S --needed --noconfirm `dkp-pacman -Slq dkp-libs | grep '^switch-'` && \
-    dkp-pacman -Scc --noconfirm
+    dkp-pacman -Scc --noconfirm && \
+    dkp-pacman -S --needed --noconfirm devkitpro-pkgbuild-helpers
 

--- a/toolchain-base/Dockerfile
+++ b/toolchain-base/Dockerfile
@@ -6,7 +6,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
     apt-get install -y apt-utils && \
-    apt-get install -y --no-install-recommends sudo ca-certificates pkg-config curl wget bzip2 xz-utils make cmake git bsdtar doxygen gnupg && \
+    apt-get install -y --no-install-recommends sudo ca-certificates pkg-config curl wget bzip2 xz-utils make cmake git bsdtar doxygen gnupg zip && \
     apt-get clean
 
 RUN wget https://github.com/devkitPro/pacman/releases/download/devkitpro-pacman-1.0.1/devkitpro-pacman.deb && \

--- a/toolchain-base/Dockerfile
+++ b/toolchain-base/Dockerfile
@@ -6,7 +6,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
     apt-get install -y apt-utils && \
-    apt-get install -y --no-install-recommends sudo ca-certificates pkg-config curl wget bzip2 xz-utils make git bsdtar doxygen gnupg && \
+    apt-get install -y --no-install-recommends sudo ca-certificates pkg-config curl wget bzip2 xz-utils make cmake git bsdtar doxygen gnupg && \
     apt-get clean
 
 RUN wget https://github.com/devkitPro/pacman/releases/download/devkitpro-pacman-1.0.1/devkitpro-pacman.deb && \


### PR DESCRIPTION
This allows building Switch homebrew with cmake, and adds zip. Zip is often used to package homebrew on the Switch.

Fixes https://github.com/devkitPro/docker/issues/3