### PR TITLE
include ``devkitarm-rules`` in ``devkita64_devkitarm``

### DIFF
--- a/devkita64_devkitarm/Dockerfile
+++ b/devkita64_devkitarm/Dockerfile
@@ -2,7 +2,7 @@ FROM devkitpro/devkita64
 
 MAINTAINER Dave Murphy <davem@devkitpro.org>
 
-RUN dkp-pacman -Sy --noconfirm devkitARM && \
+RUN dkp-pacman -Sy --noconfirm devkitARM devkitarm=rules && \
     dkp-pacman -Scc --noconfirm
 
 ENV DEVKITARM=/opt/devkitpro/devkitARM

--- a/devkita64_devkitarm/Dockerfile
+++ b/devkita64_devkitarm/Dockerfile
@@ -2,7 +2,7 @@ FROM devkitpro/devkita64
 
 MAINTAINER Dave Murphy <davem@devkitpro.org>
 
-RUN dkp-pacman -Sy --noconfirm devkitARM devkitarm=rules && \
+RUN dkp-pacman -Sy --noconfirm devkitARM devkitarm-rules && \
     dkp-pacman -Scc --noconfirm
 
 ENV DEVKITARM=/opt/devkitpro/devkitARM


### PR DESCRIPTION
fixes building on newer devkitARM versions, as the rules were split into a separate package