### PR TITLE
Add Wii and WiiU SDL packages to devkitppc

### DIFF
--- a/devkitppc/Dockerfile
+++ b/devkitppc/Dockerfile
@@ -4,5 +4,7 @@ MAINTAINER Dave Murphy <davem@devkitpro.org>
 
 RUN dkp-pacman -Syyu --noconfirm gamecube-dev wii-dev wiiu-dev && \
     dkp-pacman -S --needed --noconfirm `dkp-pacman -Slq dkp-libs | grep '^ppc-'` && \
+	dkp-pacman -S --needed --noconfirm `dkp-pacman -Slq dkp-libs | grep '^wii-sdl'` &&\
+	dkp-pacman -S --needed --noconfirm `dkp-pacman -Slq dkp-libs | grep '^wiiu-sdl2'` &&\
     dkp-pacman -Scc --noconfirm
 ENV DEVKITPPC=${DEVKITPRO}/devkitPPC


### PR DESCRIPTION
The devkitPPC docker image doesn't contain SDL packages for Wii or Wii U since it only installs the dkp-libs that start with `ppc-`. This update also installs the packages that start with `wii-sdl` and `wiiu-sdl` so any projects using those packages can build using this image.