### PR TITLE
toolchain-base: always grab devkitpro-pkgbuild-helpers

### DIFF
--- a/toolchain-base/Dockerfile
+++ b/toolchain-base/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update && \
 RUN wget https://github.com/devkitPro/pacman/releases/latest/download/devkitpro-pacman.amd64.deb && \
     gdebi -n devkitpro-pacman.amd64.deb && \
     rm devkitpro-pacman.amd64.deb && \
+    dkp-pacman -S --needed --noconfirm devkitpro-pkgbuild-helpers \
     dkp-pacman -Scc --noconfirm
 
 ENV DEVKITPRO=/opt/devkitpro


### PR DESCRIPTION
devkitpro-pkgbuild-helpers should be installed so programs can be built using the devkitPro cmake toolchain files