### PR TITLE
Upgrade to Debian Buster

### DIFF
--- a/toolchain-base/Dockerfile
+++ b/toolchain-base/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch-slim
+FROM debian:buster-slim
 
 MAINTAINER Dave Murphy <davem@devkitpro.org>
 


### PR DESCRIPTION
It has Git version 2.20, so GitHub Action can pull repo with `actions/checkout@v2` successfully