### PR TITLE
Actually clear pacman cache

### DIFF
--- a/devkitppc/Dockerfile
+++ b/devkitppc/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Dave Murphy <davem@devkitpro.org>
 RUN dkp-pacman -Syyu --noconfirm gamecube-dev wii-dev wiiu-dev && \
     dkp-pacman -S --needed --noconfirm ppc-portlibs gamecube-portlibs wii-portlibs wiiu-portlibs && \
     dkp-pacman -S --needed --noconfirm devkitARM && \
-    dkp-pacman -Scc --noconfirm
+    yes | dkp-pacman -Scc
 
 ENV DEVKITPPC=${DEVKITPRO}/devkitPPC
 ENV DEVKITARM=/opt/devkitpro/devkitARM


### PR DESCRIPTION
The original `--noconfirm` caused pacman to not clean the `/opt/devkitpro/pacman/var/cache/pacman/pkg` directory.
This change will ensure the cache is cleared properly, and should shrink the image a bit further.

Open question: Should devkitARM be included in the devkitPPC image?