### PR TITLE
Add dkp-toolchain-vars package to docker images

### DIFF
--- a/devkita64/Dockerfile
+++ b/devkita64/Dockerfile
@@ -6,7 +6,7 @@ RUN dkp-pacman -Syyu --noconfirm && \
     dkp-pacman -S --needed --noconfirm switch-dev && \
     dkp-pacman -S --needed --noconfirm switch-portlibs && \
     dkp-pacman -S --needed --noconfirm devkitARM && \
+    dkp-pacman -S --needed --noconfirm dkp-toolchain-vars && \
     yes | dkp-pacman -Scc
 
 ENV DEVKITARM=/opt/devkitpro/devkitARM
-

--- a/devkitarm/Dockerfile
+++ b/devkitarm/Dockerfile
@@ -5,6 +5,7 @@ MAINTAINER Dave Murphy <davem@devkitpro.org>
 RUN dkp-pacman -Syyu --noconfirm && \
     dkp-pacman -S --needed --noconfirm 3ds-dev nds-dev gp32-dev gba-dev gp2x-dev && \
     dkp-pacman -S --needed --noconfirm 3ds-portlibs nds-portlibs armv4t-portlibs && \
+    dkp-pacman -S --needed --noconfirm dkp-toolchain-vars && \
     yes | dkp-pacman -Scc
 
 ENV DEVKITARM=${DEVKITPRO}/devkitARM

--- a/devkitppc/Dockerfile
+++ b/devkitppc/Dockerfile
@@ -5,6 +5,7 @@ MAINTAINER Dave Murphy <davem@devkitpro.org>
 RUN dkp-pacman -Syyu --noconfirm gamecube-dev wii-dev wiiu-dev && \
     dkp-pacman -S --needed --noconfirm ppc-portlibs gamecube-portlibs wii-portlibs wiiu-portlibs && \
     dkp-pacman -S --needed --noconfirm devkitARM && \
+    dkp-pacman -S --needed --noconfirm dkp-toolchain-vars && \
     yes | dkp-pacman -Scc
 
 ENV DEVKITPPC=${DEVKITPRO}/devkitPPC


### PR DESCRIPTION
This PR adds the dkp-toolchain-vars package to the docker images.

Even if this might not be necessary this helps for CI scenarios where packages that define "dkp-toolchain-vars" as a make dependency in their `PKGBUILD` files currently can't be build. Since we can't install packages during CI execution we need to include it in the image (as using the ignore dependencies option is even worse).